### PR TITLE
Unconex2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .vscode/settings.json
 py/rotseana/vsp/ceph_tools/general/getphaseplot.py
+py/rotseana/vsp/ceph_tools/general/ignore

--- a/py/rotseana/vsp/ceph_tools/general/unconex2.py
+++ b/py/rotseana/vsp/ceph_tools/general/unconex2.py
@@ -1,0 +1,408 @@
+import math
+import argparse
+import glob
+import os
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.io import readsav
+import scipy
+from scipy import stats as st
+from astropy.io import fits
+from decimal import Decimal
+plt.rc('legend', fontsize = 12)
+
+def evaluateBooleanArg(argument):
+    if argument == True or argument == 'True' or argument == 'true' or argument == 'Yes' or argument == 'yes' or argument == 'Y' or argument == 'y':
+        argument = True
+    elif argument == False or argument == 'False' or argument == 'false' or argument == 'No' or argument == 'no' or argument == 'N' or argument == 'n':   
+        argument = False
+    else:
+        argument = float(argument)
+    return argument
+
+def openFile(file):
+    data = list(open(file).read().splitlines())
+    data = [x.split() for x in data]
+    data = [[float(n) for n in x] for x in data]
+    return data
+
+def read_fits_file(file, fits_index=1):
+    try:
+        hdus = fits.open(file, memmap=True)
+        hdus_ext = hdus[fits_index]
+        match = hdus_ext.data
+    except Exception as e:
+        raise Exception("cannot read fits data from file: %s" % (file,)) from e
+    return match, 'ROTSE3'
+
+def read_match_file(file, *args, **kwargs):
+    try:
+        match = readsav(file)['match']
+    except Exception as e:
+        raise Exception("cannot read match data from file: %s" % (file,)) from e
+    return match, 'ROTSE1'
+
+def get_data_file_rotse(file):
+    if not os.path.isfile(file):
+        raise Exception("file not found: %s" % (file,))  
+    file_ext = file.rpartition('.')[2]
+    if file_ext == 'fit':
+        return 3
+    else:
+        return 1
+
+def read_data_file(file, fits_index=1, tmpdir='/tmp'):
+    if not os.path.isfile(file):
+        raise Exception("file not found: %s" % (file,))
+    file_ext = file.rpartition('.')[2]
+    if file_ext == 'fit':
+        match, rotse = read_fits_file(file, fits_index)
+    else:
+        match, rotse = read_match_file(file)
+    return match, rotse
+
+def get_data(refra, refdec, match):
+    match_file = None
+    if isinstance(match, str):
+        match_file = match
+        match, tele = read_data_file(match_file)
+    match_ra = match.field('RA')[0]
+    match_dec = match.field('DEC')[0]
+    cond = np.logical_and.reduce((np.abs(match_ra-refra) < 0.001, np.abs(match_dec-refdec) < 0.001))
+    goodobj = np.where(cond)
+    objid = goodobj[0]
+    match_m_lim = match['STAT'][0]['M_LIM']
+    match_obstime = match['STAT'][0]['OBSTIME'] ## gets the observation times
+    match_exptime = match.field('EXPTIME')[0]
+    match_merr = match.field('MERR')[0][objid][0]
+    match_m = match.field('M')[0][objid][0]
+    match_flags = match.field('FLAGS')[0][objid][0] # get all of the flags for this objid
+    match_jd = match.field('JD')[0]
+    curve = list()
+    for q in range(len(match_jd)):
+        flags = match_flags[q]            
+        epoch = float((math.floor(match_jd[q])) + (Decimal(str(match_obstime[q] / 86400)) % 1))
+        mag = match_m[q]
+        magerr = match_merr[q]
+        obstime = match_obstime[q]
+        exptime = match_exptime[q]
+        m_lim = match_m_lim[q]
+        point = [epoch, mag, magerr, exptime, m_lim, obstime, flags]
+        curve.append(point)
+    return curve
+
+def get_matchstructs(match_structures):
+    cwd = os.getcwd()
+    os.chdir(match_structures)
+    temp_matchs = list()
+    fits = glob.glob("*.fit")
+    dats = glob.glob("*.dat")
+    datcs = glob.glob("*.datc")
+    for fit in fits:
+        temp_matchs.append(fit)
+    for dat in dats:
+        temp_matchs.append(dat)
+    for datc in datcs:
+        temp_matchs.append(datc)
+    return temp_matchs, cwd
+
+def find_target(vra, vdec, temp_matchs, verbose):
+    matchs = []
+    target_lc = []
+    nightInterval = []
+    for match in temp_matchs:
+        try:
+            lc = get_data(vra, vdec, match)
+            nightInterval.append([lc[0][0], lc[-1][0]])
+            for i in lc:
+                target_lc.append(i)
+            print(f"Target found in {match}")
+            matchs.append(match)
+        except IndexError:
+            if verbose:
+                print(f"Cannot find target in {match}; this match structure was removed from the list")
+            pass
+    return matchs, target_lc, nightInterval
+
+def print_lightcurve(lightcurve, xerror, final):
+    if final:
+        print("***FINAL TARGET LIGHTCURVE***")
+        if xerror:
+            for i in lightcurve:
+                print(i[0], i[1], i[2], i[3])
+        else:
+            for i in lightcurve:
+                print(i[0], i[1], i[2])
+    else:
+        print("***TARGET LIGHTCURVE***")
+        for i in lightcurve:
+            print(i[0], i[1], i[2], i[3], i[4], i[5], i[6])
+
+def save_lightcurve(lightcurve, cwd, vra, vdec):
+    os.chdir(cwd)
+    filename = 'lightcurve_ra'+str(vra)+'_dec'+str(vdec)+'.dat'
+    print(f"You can find a copy of the light curve named {filename} in the same directory as unconex2.py")
+    np.savetxt(filename, lightcurve, fmt = '%.11f')
+
+def save_log(log_params, cwd, vra, vdec):
+    os.chdir(cwd)
+    filename = 'log_ra'+str(vra)+'_dec'+str(vdec)+'.dat'
+    print(f"You can find a copy of the log file named {filename} in the same directory as unconex2.py")
+    open(f'{filename}', 'w').writelines('%s\n' % x for x in log_params)
+
+def getBinaryStr(bitSum):
+    binaryStr = bin(bitSum).replace('0b','') #transform to binary
+    binaryStr = binaryStr[::-1] #this reverses an array
+    while len(binaryStr) < 8: 
+        binaryStr += '0' ## add bits until we have a binary number on 8 bits (as used by SExtractor)
+    binaryStr = binaryStr[::-1]
+    return binaryStr
+
+def applyBitmask(lightCurve, bitmask):
+    flagged = [[] for x in range(9)]
+    for x in lightCurve:
+        x[6] = getBinaryStr(x[6])
+        for i in range(len(x[6])):
+            if x[6][i] == '1' and bitmask[i] == '1':
+                flagged[i].append(x)
+                flagged[8].append(x)
+    return flagged
+
+def unconex(lightCurve, schedule, threshold, xerror):
+    confirmation = [[0, 0] for x in lightCurve] # Array for confirmation state of each observation
+    consistence = [[0, 0] for x in lightCurve] # Array for consistence state of each observation
+    filtLightCurve = [] # Array for filtered light curve
+    graceTime = 40 # Grace time definition
+    readoutTime = 10 
+    for x in range(len(confirmation) - 1): # Loop through each entry in confirmation
+        if abs(lightCurve[x][0] - lightCurve[x + 1][0]) <= (lightCurve[x][3] + graceTime) / 86400:
+            confirmation[x][1] += 1
+            confirmation[x + 1][0] += 1
+    for x in range(len(consistence) - 1):
+        if confirmation[x][1] == 1 and confirmation[x + 1][0] == 1:
+            if abs(lightCurve[x][1] - lightCurve[x + 1][1]) <= threshold * (((lightCurve[x][2] ** 2) + (lightCurve[x + 1][2] ** 2)) ** 0.5):
+                consistence[x][1] += 1
+                consistence[x + 1][0] += 1
+        else: 
+            pass
+    confirmationCount = 0
+    consistenceCount = 0
+    for x in range(len(lightCurve)):
+        if confirmation[x][0] == 1 or confirmation[x][1] == 1:
+            confirmationCount += 1
+        if consistence[x][0] == 1 or consistence[x][1] == 1:
+            consistenceCount += 1
+    print(f'{confirmationCount} observations were confirmed')
+    print(f'{consistenceCount} observations are consistent')
+    averaged = []
+    i = 0
+    while i in range(len(lightCurve)):
+        if i == len(lightCurve) - 1:
+            if consistence[i][0] == 1 and consistence[i - 1][1] == 1:
+                filtLightCurve.append([lightCurve[i][0], lightCurve[i][1], lightCurve[i][2]])
+            i += 1
+        elif consistence[i][1] == 1 and consistence[i + 1][0] == 1:
+            meanEpoch = (lightCurve[i][0] + lightCurve[i + 1][0] + (lightCurve[i + 1][3] + readoutTime) / 86400) / 2
+            meanMag = np.average([lightCurve[i][1], lightCurve[i + 1][1]], weights = [1 / lightCurve[i][2] ** 2, 1 / lightCurve[i + 1][2] ** 2])
+            if abs(lightCurve[i][1] - lightCurve[i + 1][1]) >= math.sqrt(2) * np.mean([lightCurve[i][2], lightCurve[i + 1][2]]):
+                meanErr = abs(lightCurve[i][1] - lightCurve[i + 1][1]) / math.sqrt(2)
+            else:
+                meanErr = np.mean([lightCurve[i][2], lightCurve[i + 1][2]]) / math.sqrt(2)
+            point = [meanEpoch, meanMag, meanErr]
+            if xerror:
+                epochErr = abs(lightCurve[i][0] - lightCurve[i + 1][0]) + lightCurve[i + 1][3] / 86400
+                point.append(epochErr)
+            filtLightCurve.append(point)
+            averaged.append([point, lightCurve[i], lightCurve[i + 1]])
+            i += 2
+        elif consistence[i][0] == 1 and consistence[i - 1][1] == 1:
+            point = [lightCurve[i][0], lightCurve[i][1], lightCurve[i][2]]
+            if xerror:
+                point.append(0)
+            filtLightCurve.append(point)
+            i += 1
+        else:
+            i += 1
+    print(f'{len(averaged) * 2} observations were averaged')
+    print(f'{len(filtLightCurve) - len(averaged)} consistent but unpaired observations were retained')
+    return filtLightCurve, averaged, confirmationCount, consistenceCount
+
+def getPlots(lightCurve, filtLightCurve, flagged, averaged, rightAscension, declination, bitmask, minUncertainty, xerror):
+    lightCurve = [[x[0], x[1], x[2]] for x in lightCurve]
+    meanErr = np.mean([x[2] for x in lightCurve])
+    filtMeanErr = np.mean([x[2] for x in filtLightCurve])
+    pairedObs = [[x[1], x[2]] for x in averaged]
+    pairedObs = [y for x in pairedObs for y in x]
+    pairedObs = [[x[0], x[1], x[2]] for x in pairedObs]
+    unpairedObs = [x for x in filtLightCurve if x in lightCurve]
+    discardedObs = [x for x in lightCurve if x not in pairedObs]
+    discardedObs = [x for x in discardedObs if x not in unpairedObs]
+    maskedObs = [x for x in lightCurve if x not in discardedObs]
+    if xerror:
+        unpairedObs = [x for x in filtLightCurve if x in [[i[0], i[1], i[2], 0] for i in lightCurve]]
+    else:
+        unpairedObs = [x for x in filtLightCurve if x in lightCurve]
+    fig, axs = plt.subplots(2, sharex = True, sharey = True)
+    ax1, ax2 = axs
+    ax1.errorbar([x[0] for x in maskedObs], [x[1] for x in maskedObs], [x[2] for x in maskedObs], fmt = 'o', color = 'tab:blue', label = f'Masked Observations ({len(maskedObs)})')
+    ax1.errorbar([x[0] for x in flagged[8]], [x[1] for x in flagged[8]], [x[2] for x in flagged[8]], fmt = '+', color = 'tab:orange', label = f'Flagged Observations ({len(flagged[8])})')
+    ax1.errorbar([x[0] for x in discardedObs], [x[1] for x in discardedObs], [x[2] for x in discardedObs], fmt = '+', color = 'tab:red', label = f'Discarded Observations ({len(discardedObs)})')
+    ax1.set_title(f'Target: {rightAscension:.7f} {declination:.7f}\nBitmask = {bitmask}, $\sigma_{{min}} = {minUncertainty}$\nUnfiltered Light Curve\n$\\bar{{\sigma}} = {meanErr:.6f}$')
+    ax1.set(xlabel = 'Time (MJD)')
+    ax1.set(ylabel = 'Magnitude')
+    ax1.grid(axis = 'both', alpha = 0.75)
+    ax1.invert_yaxis()
+    ax1.legend()
+    if xerror:
+        ax2.errorbar([x[0] for x in filtLightCurve if x not in unpairedObs], [x[1] for x in filtLightCurve if x not in unpairedObs], [x[2] for x in filtLightCurve if x not in unpairedObs], [x[3] for x in filtLightCurve if x not in unpairedObs], fmt = 'o', color = 'tab:blue', label = f'Averaged Observations ({len(filtLightCurve) - len(unpairedObs)})')
+        ax2.errorbar([x[0] for x in unpairedObs], [x[1] for x in unpairedObs], [x[2] for x in unpairedObs], fmt = 'o', color = 'tab:green', label = f'Unaveraged Observations ({len(unpairedObs)})')
+    else:
+        ax2.errorbar([x[0] for x in filtLightCurve if x not in unpairedObs], [x[1] for x in filtLightCurve if x not in unpairedObs], [x[2] for x in filtLightCurve if x not in unpairedObs], fmt = 'o', color = 'tab:blue', label = f'Averaged Observations ({len(filtLightCurve) - len(unpairedObs)})')
+        ax2.errorbar([x[0] for x in unpairedObs], [x[1] for x in unpairedObs], [x[2] for x in unpairedObs], fmt = 'o', color = 'tab:green', label = f'Unaveraged Observations ({len(unpairedObs)})')   
+    ax2.set_title(f'Filtered Light Curve\n$\\bar{{\sigma}} = {filtMeanErr:.6f}$')
+    ax2.set(xlabel = 'Time (MJD)')
+    ax2.set(ylabel = 'Magnitude')
+    ax2.grid(axis = 'both', alpha = 0.75)
+    ax2.legend()
+
+def getTestPlots(lightCurve, filtLightCurve, averaged, flagged, rightAscension, declination):
+    fig, axs = plt.subplots(1)
+    lightCurve = [[x[0], x[1], x[2]] for x in lightCurve]
+    pairedObs = [[x[1], x[2]] for x in averaged]
+    pairedObs = [y for x in pairedObs for y in x]
+    pairedObs = [[x[0], x[1], x[2]] for x in pairedObs]
+    avgObs = [x[0] for x in averaged]
+    unpairedObs = [x for x in filtLightCurve if x not in avgObs]
+    discardedObs = [x for x in lightCurve if x not in pairedObs]
+    discardedObs = [x for x in discardedObs if x not in unpairedObs]
+    axs.set_title(f'Target: {rightAscension:.7f} {declination:.7f}\nBitmask = {bitmask}, $\sigma_{{min}} = {minUncertainty}$\nLight Curve')
+    axs.errorbar([x[0] for x in flagged[8]], [x[1] for x in flagged[8]], [x[2] for x in flagged[8]], fmt = '+', color = 'tab:orange', label = f'Flagged Observations ({len(flagged[8])})')
+    axs.errorbar([x[0] for x in pairedObs], [x[1] for x in pairedObs], [x[2] for x in pairedObs], fmt = 'o', color = 'tab:blue', label = f'Paired Observations ({len(pairedObs)})')
+    axs.errorbar([x[0] for x in unpairedObs], [x[1] for x in unpairedObs], [x[2] for x in unpairedObs], fmt = 'o', color = 'tab:green', label = f'Unpaired Observations ({len(unpairedObs)})')
+    axs.errorbar([x[0] for x in avgObs], [x[1] for x in avgObs], [x[2] for x in avgObs], fmt = 'o', color = 'tab:purple', label = f'Averaged Observations ({len(averaged)})')
+    axs.errorbar([x[0] for x in discardedObs], [x[1] for x in discardedObs], [x[2] for x in discardedObs], fmt = '+', color = 'tab:red', label = f'Discarded Observations ({len(discardedObs)})')
+    axs.set(xlabel = 'Time (MJD)')
+    axs.set(ylabel = 'Magnitude')
+    axs.grid(axis = 'both', alpha = 0.75)
+    axs.invert_yaxis()
+    axs.legend()
+
+
+def sexa2deci(rightAscension, declination):
+    rightAscension = float(''.join(rightAscension[:2])) * 15 + float(''.join(rightAscension[2:4])) * 0.25 + float(''.join(rightAscension[4:])) / 240
+    declination = float(''.join(declination[:2])) + float(''.join(declination[2:4])) / 60 + float(''.join(declination[4:])) / 3600
+    return rightAscension, declination
+
+def main(fileDir, schedule, rightAscension, declination, threshold, bitmask, minUncertainty, xerror, plot, save, verbose, log, night, dev):
+    if rightAscension[6] == '.':
+        rightAscension, declination = sexa2deci(rightAscension, declination)
+    else:
+        rightAscension = float(rightAscension)
+        declination = float(declination)
+    allMatchStructs, cwd = get_matchstructs(fileDir)
+    matchStructs, extractedObs, nightInterval = find_target(rightAscension, declination, allMatchStructs, verbose)
+    if len(matchStructs) == 0:
+        print("Unable to locate target in the match structure directory, please verify that the input coordinates are correct")
+        sys.exit()
+    if night != None:
+        extractedObs = [x for x in extractedObs if nightInterval[night - 1][0] <= x[0] <= nightInterval[night - 1][1]]
+    print(f'{len(extractedObs)} observations of the target were extracted')
+    lightCurve = [x for x in extractedObs if 0 < x[1] < 99]
+    print(f'{len(lightCurve)} total observations in target\'s light curve after {len(extractedObs) - len(lightCurve)} unphysical observations were removed')
+    if verbose:
+        print_lightcurve(lightCurve, xerror, False)
+    binaryBitmask = getBinaryStr(bitmask)
+    flagged = applyBitmask(lightCurve, binaryBitmask)
+    if verbose:
+        if binaryBitmask[7] == '1':
+            print(f'{len(flagged[7])} observations flagged as biased were removed')
+        if binaryBitmask[6] == '1':
+            print(f'{len(flagged[6])} observations flagged as deblended were removed')
+        if binaryBitmask[5] == '1':
+            print(f'{len(flagged[5])} observations flagged as saturated were removed')
+        if binaryBitmask[4] == '1':
+            print(f'{len(flagged[4])} observations flagged as too close to an image boundary were removed')
+        if binaryBitmask[3] == '1':
+            print(f'{len(flagged[3])} observations flagged as having an incomplete or corrupt photometric aperture were removed')
+        if binaryBitmask[2] == '1':
+            print(f'{len(flagged[2])} observations flagged as having an incomplete or corrupt isophotal footprint were removed')
+        if binaryBitmask[1] == '1':
+            print(f'{len(flagged[1])} observations flagged as having a memory overflow during deblending were removed')
+        if binaryBitmask[0] == '1':
+            print(f'{len(flagged[0])} observations flagged as having a memory overflow during extraction were removed')
+    lightCurve = [x for x in lightCurve if  x not in flagged[8]]
+    print(f'{len(lightCurve)} observations in target\'s light curve after {len(flagged[8])} flagged observations were removed')
+    for x in lightCurve:
+        if x[2] < minUncertainty:
+            x[2] = minUncertainty
+    filtLightCurve, averaged, confirmationCount, consistenceCount = unconex(lightCurve, schedule, threshold, xerror)
+    if verbose:
+        print_lightcurve(filtLightCurve, xerror, True)
+    if plot:
+        getPlots(lightCurve, filtLightCurve, flagged, averaged, rightAscension, declination, bitmask, minUncertainty, xerror)
+    if save:
+        save_lightcurve(filtLightCurve, cwd, rightAscension, declination)
+    if log:
+        logParams = [f'Extracted observations: {len(extractedObs)}', f'Physical observations: {len(lightCurve) + len(flagged[8])}', f'Masked observations: {len(lightCurve)}', 
+        f'Flagged observations: {len(flagged[8])}', f'Confirmed observations: {confirmationCount}', f'Constistent observations: {consistenceCount}', 
+        f'Averaged observations: {len(averaged) * 2}', f'Unpaired observations: {len(filtLightCurve) - len(averaged)}', f'Filtered observations: {len(filtLightCurve)}']
+        save_log(logParams, cwd, rightAscension, declination)
+    for x in averaged:
+        x[1] = [x[1][0], x[1][1], x[1][2], x[1][3]]
+        x[2] = [x[2][0], x[2][1], x[2][2], x[2][3]]
+    if dev:  
+        avgObs = [x[0] for x in averaged]
+        priorObs = [x[1] for x in averaged]
+        subsequentObs = [x[2] for x in averaged]
+        os.chdir(cwd)
+        np.savetxt('avgobs_ra'+str(rightAscension)+'_dec'+str(declination)+'.dat', avgObs, fmt = '%.11f')
+        np.savetxt('priorobs_ra'+str(rightAscension)+'_dec'+str(declination)+'.dat', priorObs, fmt = '%.11f')
+        np.savetxt('subobs_ra'+str(rightAscension)+'_dec'+str(declination)+'.dat', subsequentObs, fmt = '%.11f')
+        getTestPlots(lightCurve, filtLightCurve, averaged, flagged, rightAscension, declination)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("fileDir", type = str, help = 'Path to match structure directory for R1/3 or light curve file for NSVS')
+parser.add_argument("schedule", choices = ['R1', 'NSVS', 'R3'], help = 'ROTSE experiment that originated data')
+parser.add_argument("ra", help = 'Target\'s right ascension')
+parser.add_argument("dec", help = 'Target\'s declination')
+parser.add_argument("--threshold", "-t", type = float, default = 2, help = 'Threshold to determine consistent observations')
+parser.add_argument("--bitmask", "-b", type = int, default = 0, help = 'Remove flagged observations with the specified bit mask')
+parser.add_argument("--minUncertainty", "-u", type = float, default = 0.02, help = 'Minimum uncertainty of magnitude measurements')
+parser.add_argument("--xerror", "-x", default = False, help = 'Calculate error along x-axis (time) when filtering data (True to enable)')
+parser.add_argument("--plot", "-p", default = True, help = 'Display target\'s light curve before and after processing (True to enable)')
+parser.add_argument("--save", "-s", default = True, help = 'Save the target\'s processed light curve to a .dat file (False to disable)')
+parser.add_argument("--verbose", "-v", default = False, help = 'Print target\'s processed light curve and additional information to terminal (True to enable)')
+parser.add_argument("--log", "-l", default = False, help = 'Save processing metrics to log file (False to disable)')
+parser.add_argument("--night", "-n", type = int, default = None, help = 'Only process the target\'s light curve for a specifc night')
+parser.add_argument("--dev", "-d", default = False, help = 'Enable developer mode to output additional data and plots')
+args = parser.parse_args()
+
+fileDir = args.fileDir
+schedule = args.schedule
+if os.path.isdir(fileDir) and schedule == 'NSVS':
+    print('ArgumentError: NSVS/Sky Patrol-schedule data can only be extracted from a .dat light curve file but a path to a directory has been given, please try again')
+    sys.exit()
+ra = args.ra
+dec = args.dec
+threshold = args.threshold
+if threshold <= 0:
+    print('ArgumentError: Value of consistency threshold must be greater than zero, please try again')
+    sys.exit()
+bitmask = args.bitmask
+minUncertainty = args.minUncertainty
+if minUncertainty < 0:
+    print('ArgumentError: Value of minimum magnitude uncertainty must be greater than or equal to zero, please try again')
+    sys.exit()
+xerror = evaluateBooleanArg(args.xerror)
+plot = evaluateBooleanArg(args.plot)
+save = evaluateBooleanArg(args.save)
+verbose = evaluateBooleanArg(args.verbose)
+log = evaluateBooleanArg(args.log)
+night = args.night
+if night != None and schedule =='NSVS':
+    print('ArgumentError: Can only plot/save indvidual nights for ROTSE-I and III data')
+    night = None
+dev = evaluateBooleanArg(args.dev)
+main(fileDir, schedule, ra, dec, threshold, bitmask, minUncertainty, xerror, plot, save, verbose, log, night, dev)
+plt.show()


### PR DESCRIPTION
Update from original Unconex to the completely reworked and refactored Unconex2

@rkehoe, @gigicu01, @rstaten, and @jalasker, this is the totally reworked and refactored update of Unconex from the original version written by me and @GrantPDonnelly to the new Unconex2.

**Major Changes Summary:**
Due to ambiguity regarding the functionality of Unconex, Unconex2 features a totally reworked data filtration process as well as additional quality control steps. 
- Filtration clearly divided into three core steps: confirmation, consistency, and averaging
- Added user-defined threshold criteria to determine consistency
- Filtration process has been generalized to allow future support for NSVS (Sky Patrol) and ROTSE-III data
- Removed limiting magnitude cut; replaced with a user-defined bitmask based on SExtractor flags
- Added user-defined minimum uncertainty value for magnitude measurements; mitigates SExtractor's underestimation of uncertainty and prevents excessive filtration in periods of rapid brightness oscillation
- Added extraction of obstime values; fractional-part of epoch values are adjusted using obstime value to increase precision and mitigate floating-point and rounding errors
- User can now specify a specific night/match structure for filtration to be performed on
- Target coordinates can now be specified in sexagesimal format (J000000.00+000000.0) in addition to decimal format 

**Technical Description:**
Unconex2 locates match structures and extracts observations largely identically to Unconex using code originally written by @danielsela42. Unconex2 retrieves a list of match structures from the user-specified directory and then searches each match structure for the target object using the user-specified right ascension and declination. Unconex2 extracts each observation's epoch, magnitude, uncertainty, exposure length, limiting magnitude, obstime, and flags, as well as recording the first and last observation in each match structure. Each observation's epoch is corrected using its obstime during extraction. Once extracted, the target's light curve is then reduced to the user-specified night/match structure, if applicable, and observations with unphysical magnitudes are removed. The light curve is then masked with the user-specified bitmask and the corresponding flagged observations are removed. The uncertainty values of each observation in the masked light curve are then compared to the user-specified minimum uncertainty value (0.02 by default) and adjusted if they are less than the minimum uncertainty. 

Unconex2 then applies the three-step filtration process to the masked light curve. First, Unconex2 confirms observations by looping through the light curve and comparing each observation's epoch to the epoch of the subsequent observation. If the absolute difference of the two epochs is less than or equal to the second observation's exposure time plus a grace period (40 seconds), the observations confirm each other. Once confirmation is complete, 

Unconex2 loops through the light curve again to check the observations' consistency. Observations can only be consistent if they are first confirmed. If two observations are confirmed and If the absolute difference of their magnitude values is less than or equal to their combined uncertainty values (computed by taking their sum in quadrature) multiplied by the threshold value, then they are consistent with each other. 

The light curve is then looped through a third and final time and each pair of consistent observations is averaged together. If an observation is consistent with the prior observation but not the subsequent observation and the prior observation has already been paired and averaged with another observation, then that observation is retained unaveraged in the filtered light curve. No consistent observations are removed. 

The averaged observation's new epoch is calculated by summing the first and second observations' epochs, the second observation's exposure length, and a readout time (10 seconds) then dividing it by 2, The new magnitude value is calculated by taking the arithmetic average of each observations' magnitude weighted by their uncertainty. The weights are 1 over the square of the respective uncertainty. The new uncertainty value is calculated by taking the absolute difference of the two observations' magnitude values and dividing it by the square root of 2 if the absolute difference is greater than or equal to the observations' mean uncertainty multiplied by the square root of 2. Otherwise, the new uncertainty value is equal to the observations' mean uncertainty divided by the square root of two. If uncertainty along the x- axis (time) is enabled, the uncertainty of the new epoch is equal to the absolute difference of the two observations' epochs plus the second observation's exposure length.

The filtered light curve is then saved to a .dat file in the same directory as unconex2.py and the target's unfiltered and filtered light curves are plotted and displayed. If enabled, a log file containing various filtration parameters will also be generated and saved to the same directory as unconex2.py

**Testing Results:**
To verify its functionality, Unconex2 was tested on two different target objects. The first object, ROTSE1 J112037.66+392100.6 (MP UMa) (170.1569167 +39.35016667), is a known DSCT variable from the xtetrans field and is relatively well behaved. The second object, ROTSE1 J232708.22+371216.9 (351.78425 +37.20469), is a known HADS variable from the sky0046 field that displays poorer and sparser data than the first object as well as varying exposure lengths. The light curves of each object are shown only for a single night/match structure

**ROTSE1 J112037.66+392100.6:**
![curves](https://user-images.githubusercontent.com/57299283/126825279-ae27a09c-c1f5-44d1-a26e-21dd164b5067.png)
This is the standard plot output by Unconex2, displaying the number of observations that fall into various categories, observations removed by the bitmask, observations discarded due to being unconfirmed or inconsistent, observations that were successfully masked, and consistent observations that were not averaged. The mean magnitude uncertainty before and after filtration are also displayed. 

![stackedcurves](https://user-images.githubusercontent.com/57299283/126825293-54268f93-5fd1-4353-b056-c82da666bb2b.png)
This plot displays the unfiltered and filtered light curves stacked on another so as to demonstrate the position of the averaged observations relative to the pairs of observations they were averaged from. This plot will only be output by Unconex2 if developer mode is enabled at runtime.

![bitmask](https://user-images.githubusercontent.com/57299283/126826074-597d9758-6081-4c20-8a63-91d32e3f1798.png)
This plot demonstrates the functionality of Unconex2's bitmask. In the previous plots, the bitmask was set to 12, meaning observations flagged as saturated or close to an image boundary would be removed. Here, the bitmask is set to 2, meaning any observation flagged as deblended would be removed. Virtually all of ROTSE1 J112037.66+392100.6's observations were flagged as deblended and Unconex2 successfully removed all observations flagged as deblended.

![minerrorcurves](https://user-images.githubusercontent.com/57299283/126826682-ee0742db-2cef-49ed-a2a9-f402f8d44adc.png)
![stackedminerror](https://user-images.githubusercontent.com/57299283/126826696-2050d532-8435-41e6-930f-3b984d39f7d9.png)
These two plots of ROTSE1 J112037.66+392100.6 demonstrate the impact of the minimum uncertainty value on the filtration process. In the previous plots the minimum uncertainty was set to 0.02 while here it was set to 0.01. This resulted in 4 additional observations being rejected due to failing the consistency check.


**ROTSE1 J232708.22+371216.9:**
![hardcurves](https://user-images.githubusercontent.com/57299283/126827149-a3c81cb8-2625-4540-98da-378c356ab359.png)
![hardstackedcurves](https://user-images.githubusercontent.com/57299283/126827163-de720df3-f26d-475b-979b-85b213c1697d.png)
These plots show the effects of filtration on a light curve with sparser and poorer quality observations. Of particular interest is the second plot, as some of the averaged observations occur after their corresponding pair on the x-axis. Inspection of the light curve revealed that exposure length varied between observations, with some having 80 second exposure lengths, half of the typical ROTSE-I 160 second exposure length.

**Basic Usage Description**:
Pending further refinement, Unconex2 should be run using the following terminal command: 'python unconex2.py path/to/match/structure/directory R1 targetRA targetDec -b 12'. If you want to use sexagesimal RA and Dec (J111111.11+222222.2), format them as '111111.11 222222.22'. Do not include the "J" or "+". This will run Unconex2 with the bitmask set to 12, to remove observations flagged as saturated or close to an image boundary, and with the default minimum uncertainty of 0.02. To only filter a light curve on a particular night, add '-n 1', replacing '1' with the number of the night you would like to filter. To print the unfiltered and filtered light curve to terminal, add '-v True' to enable verbose mode. A more complete description of the various command line arguments, as well as how to construct a bitmask, will be included in a readme that will be added in a future pull request.

**Future Objectives**:
- Add a detailed readme file
- Fully evaluate the usefulness of Unconex2 with orphans-scheduled data
- Add support for NSVS/Sky Patrol scheduled data
- Distinguish between unconfirmed and inconsistent observations in plots
- If necessary, add local fitting to correct potential excessive filtering in rapidly varying regions of light curves 
- Add ROTSE-III support (long term)
- Simplify existing code (ongoing basis); possibly combine confirmation and consistency into a single loop
- 

Co-Authored-By: george_pantelimon <80425896+gigicu01@users.noreply.github.com>