### PR TITLE
Unconex2R3 match structs

### DIFF
--- a/py/rotseana/vsp/ceph_tools/general/unconex2.py
+++ b/py/rotseana/vsp/ceph_tools/general/unconex2.py
@@ -75,9 +75,9 @@ def get_data(refra, refdec, match):
     cond = np.logical_and.reduce((np.abs(match_ra-refra) < 0.001, np.abs(match_dec-refdec) < 0.001))
     goodobj = np.where(cond)
     objid = goodobj[0]
-    # test edit
-    match_m_lim = match['STAT'][0]['M_LIM']
-    match_obstime = match['STAT'][0]['OBSTIME'] ## gets the observation times
+    #match_m_lim = match['STAT'][0]['M_LIM']
+    match_m_lim = match.field('M_LIM')[0]
+    match_obstime = 86400.0*(match.field('JD')[0] % 1)   # hack until fix match str.
     match_exptime = match.field('EXPTIME')[0]
     match_merr = match.field('MERR')[0][objid][0]
     match_m = match.field('M')[0][objid][0]

--- a/py/rotseana/vsp/ceph_tools/general/unconex2.py
+++ b/py/rotseana/vsp/ceph_tools/general/unconex2.py
@@ -75,6 +75,7 @@ def get_data(refra, refdec, match):
     cond = np.logical_and.reduce((np.abs(match_ra-refra) < 0.001, np.abs(match_dec-refdec) < 0.001))
     goodobj = np.where(cond)
     objid = goodobj[0]
+    # test edit
     match_m_lim = match['STAT'][0]['M_LIM']
     match_obstime = match['STAT'][0]['OBSTIME'] ## gets the observation times
     match_exptime = match.field('EXPTIME')[0]


### PR DESCRIPTION
This PR adjusts unconex2.py so that it will work with ROTSE-III match structures.  This required obtaining OBSTIME and M_LIM from the field area of the match structure, since the 'stat' area does not exist for R3 structures.  

Please note, this is a hack for OBSTIME, since I had to use JD modulo the integer part and I am not sure the decimal part has the same 0.01 s precision that OBSTIME in the FITS headers had (i.e. the headers are in the STAT struct for ROTSE-I).  So this will need to be checked, but to with 10 seconds or so, the hack seems to be okay.  

@jjuvan Could you please try this on a ROTSE-I match structure and verify it is working fine?  Works for R3 and is otherwise ready to merge.