### PR TITLE
Update lcvis.py

### DIFF
--- a/py/rotseana/vsp/ceph_tools/general/lcvis.py
+++ b/py/rotseana/vsp/ceph_tools/general/lcvis.py
@@ -15,13 +15,13 @@ def lcvis( data, obj_name, period_initial ):
     global x_sin
     global y_sin
     global modelx_manualshift
-    global y_sin_shift
-    global y_sin_datashift
+    global y_shift
+    global y_datashift
     global modelx_manualshift
     global modely_manualshift
-    global y_parab_shift
     global amp_data
     global amp_manual
+    global min_width
     global sin_width
     global curve_type
     global centered
@@ -30,10 +30,13 @@ def lcvis( data, obj_name, period_initial ):
     global per_min
     global amp_max
     global amp_min
+    global chi_width
     global modelx_max
     global modelx_min
     global modely_max
     global modely_min
+    global minwidth_mi
+    global minwidth_max
     global slider
     global Badd_id
     global Bsub_id
@@ -65,7 +68,7 @@ def lcvis( data, obj_name, period_initial ):
 
 
 
-    #FIND_X2 function finds the x2 value of the data, fit to either a sine curve or absolute value sine curve
+    #FIND_X2 function finds the x2 value of the data, fit to either a sine curve or sech-sec curve
     def find_X2(x_val, y_obs, y_exp, phased_data):
         #find the x2 value of the data, with expected data fitted to 1 cycle/phase sine curve
         if (curve_type == 'sine'):
@@ -86,27 +89,38 @@ def lcvis( data, obj_name, period_initial ):
                 x2_list.append(x2)
             output_x2 = sum(x2_list) / df
             return output_x2
-        #find the x2 value of the datas extrema, with expected data fitted to 2 cycles/phase sine curve or absolute value sine curve
-        if (curve_type == 'abs sine'):
+        #find the x2 value of the datas extrema, with expected data fitted to 2 cycles/phase sine curve or sech-sec curve
+        if (curve_type == 'sech_sec') or (curve_type == 'abs_sine'):
             global amp_data
             global amp_manual
             global modelx_manualshift
-            global y_parab_shift
-            x_vals = np.arange(0,1,0.001)
-            x_min = x_vals[0]
-            y_min = -abs(np.sin((sin_width * (x_min - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
-            for x in x_vals:
-                y_val = -abs(np.sin((sin_width * (x - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
-                if y_val > y_min:
-                    y_min = y_val
-                    x_min = x
-            
-            if x_min < 0.5:
+            #x_vals = np.arange(0,1,0.0001)
+            x_min = 0.25 + modelx_manualshift + 0.0001
+            while x_min > 1:
+                x_min = x_min - 1
+            while x_min < 0:
                 x_min = x_min + 1
-            x_min1_low = x_min - 0.1
-            x_min1_up = x_min + 0.1
-            x_min2_low = x_min1_low - 0.1
-            x_min2_up = x_min1_up + 0.1
+            x_min1_low = x_min - chi_width/2
+            x_min1_up = x_min + chi_width/2
+            x_min2_low = x_min1_low + 0.5
+            x_min2_up = x_min1_up + 0.5
+            if x_min1_low < 0:
+                x_min1_low = x_min1_low + 1
+                x_min1_up = x_min1_up + 1
+            elif x_min1_low > 1:
+                x_min1_low = x_min1_low - 1
+                x_min1_up = x_min1_up - 1
+            if x_min2_low < 0:
+                x_min2_low = x_min2_low + 1
+                x_min2_up = x_min2_up + 1
+            elif x_min2_low > 1:
+                x_min2_low = x_min2_low - 1
+                x_min2_up = x_min2_up - 1
+            
+            min1_l.set_xdata(x_min1_low)
+            min1_r.set_xdata(x_min1_up)
+            min2_l.set_xdata(x_min2_low)
+            min2_r.set_xdata(x_min2_up)
             
             x_l = list()
             y_exp_l = list()
@@ -189,64 +203,93 @@ def lcvis( data, obj_name, period_initial ):
         q.remove()
         q = ax.errorbar(x1,y1,yerr=yerror,fmt="o",c='tab:blue',elinewidth=1)
 
-        x_sin_curve = np.arange(0,2,0.001)
-
-        y_sin_datashift = 0.5 * (max(y1)+min(y1))
-        y_sin_shift = modely_manualshift + y_sin_datashift
+        y_datashift = 0.5 * (max(y1)+min(y1))
+        y_shift = modely_manualshift + y_datashift
         
-        x_sin_scatter = x1
-        y_sin_scatter = list()
+        x_scatter = x1
+        y_scatter = list()
 
         if curve_type == 'sine':
             #update sine curve
-
-            y_sin_curve = np.sin((sin_width * (x_sin_curve - modelx_manualshift))) * (amp_data + amp_manual) + y_sin_shift
-            curve.set_ydata(y_sin_curve)
-
-            #update sine scatter
-            for x_val in x_sin_scatter:
-                y_val = np.sin((sin_width * (x_val - modelx_manualshift))) * (amp_data + amp_manual) + y_sin_shift
-                y_sin_scatter.append(y_val)
-            d2 = np.vstack((x_sin_scatter,y_sin_scatter))
-            data_expected.set_offsets(d2.T)
-
-            #recalculate x2
-            x2_calculated = find_X2(x_sin_scatter, y1, y_sin_scatter, phased)
-
-        if curve_type == 'abs sine':
-            #update absolute sine curve
+            x_curve = np.arange(0,2,0.0001)
             
-            y_sin_curve = -abs(np.sin((sin_width * (x_sin_curve - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
+            y_sin_curve = np.sin((sin_width * (x_curve - modelx_manualshift))) * (amp_data + amp_manual) + y_shift
             curve.set_ydata(y_sin_curve)
 
             #update sine scatter
-            for x_val in x_sin_scatter:
-                y_val = -abs(np.sin((sin_width * (x_val - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
-                y_sin_scatter.append(y_val)
-            d2 = np.vstack((x_sin_scatter,y_sin_scatter))
+            for x_val in x_scatter:
+                y_val = np.sin((sin_width * (x_val - modelx_manualshift))) * (amp_data + amp_manual) + y_shift
+                y_scatter.append(y_val)
+            d2 = np.vstack((x_scatter,y_scatter))
             data_expected.set_offsets(d2.T)
 
             #recalculate x2
-            x2_calculated = find_X2(x_sin_scatter, y1, y_sin_scatter, phased)
+            x2_calculated = find_X2(x_scatter, y1, y_scatter, phased)
+
+        elif curve_type == 'sech_sec':
+            #update absolute sine curve
+            x_curve = np.arange(0.0005,2.0005,0.0001)
+            y_sec_curve = -(amp_data + amp_manual) / ( np.cosh((min_width) / np.cos(2 * np.pi * (x_curve - modelx_manualshift))) ) + y_shift
+            
+            curve.set_ydata(y_sec_curve)
+
+            #update sine scatter
+            for x_val in x_scatter:
+                y_val = -(amp_data + amp_manual) / ( np.cosh((min_width) / np.cos(2 * np.pi * (x_val - modelx_manualshift))) ) + y_shift
+                y_scatter.append(y_val)
+            d2 = np.vstack((x_scatter,y_scatter))
+            data_expected.set_offsets(d2.T)
+
+            #recalculate x2
+            x2_calculated = find_X2(x_scatter, y1, y_scatter, phased)
+        
+        elif curve_type == 'abs_sine':
+            #update absolute sine curve
+            x_curve = np.arange(0,2,0.0001)
+            
+            y_sin_curve = -abs(np.sin((sin_width * (x_curve - modelx_manualshift - 0.25))) * (amp_data + amp_manual)) + y_shift
+            curve.set_ydata(y_sin_curve)
+
+            #update sine scatter
+            for x_val in x_scatter:
+                y_val = -abs(np.sin((sin_width * (x_val - modelx_manualshift - 0.25))) * (amp_data + amp_manual)) + y_shift
+                y_scatter.append(y_val)
+            d2 = np.vstack((x_scatter,y_scatter))
+            data_expected.set_offsets(d2.T)
+
+            #recalculate x2
+            x2_calculated = find_X2(x_scatter, y1, y_scatter, phased)
 
         #update figure titles
         
         if curve_type == 'sine':
             eq_info.set_text('Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * sin[' + str( round(sin_width,6) )
-                                + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_sin_shift,6)) + '\n' 
+                                + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_shift,6)) + '\n' 
                                 + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
                                 + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
                                 + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
             chi_info.set_text('X2: ' + str( round(x2_calculated,6) ))
-        elif curve_type == 'abs sine':
+        elif curve_type == 'sech_sec':
+            eq_info.set_text('Model Equation: -' + str( round(amp_data + amp_manual, 6) ) + ' * sech{' + str( round(min_width,6) ) 
+                                + ' * sec[2pi * (x - ' + str(round(modelx_manualshift,6)) + ')]} + ' + str(round(y_shift,6)) + '\n' 
+                                + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
+                                + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
+                                + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) + '\n'
+                                + 'Minimum Extrema Width: ' + str( round( min_width, 6) ) )
+            chi_info.set_text('Red Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
+                                + 'Green Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
+                                + 'Maxima X2: ' + str( round(x2_calculated[2],6) ) + '\n'
+                                + 'Minima X2 Width: ' + str( round(chi_width,6) ))
+        elif curve_type == 'abs_sine':
             eq_info.set_text('Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * |sin[' + str( round(sin_width,6) )
-                                + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')]| + ' + str( round(y_sin_shift,6)) + '\n' 
+                                + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')]| + ' + str( round(y_shift,6)) + '\n' 
                                 + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
                                 + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
                                 + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
-            chi_info.set_text('First Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
-                                + 'Second Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
-                                + 'Maxima X2: ' + str( round(x2_calculated[2],6) ))
+            chi_info.set_text('Red Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
+                                + 'Green Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
+                                + 'Maxima X2: ' + str( round(x2_calculated[2],6) ) + '\n'
+                                + 'Minima X2 Width: ' + str( round(chi_width,6) ) )
             
         text.set_text("Curve type = " + curve_type + "          "
                         + arg_selected + " Stepsize = " + str(round(slider.valstep,6)) + "          "
@@ -269,8 +312,11 @@ def lcvis( data, obj_name, period_initial ):
     #EVALUATOR determines whether or not the input value can be evaluated, allows textboxes to be cleared and reset
     def evaluator(text):
         try:
-            eval(text)
-            return True
+            num = eval(text)
+            if isinstance(num, int) or isinstance(num, float):
+                return True
+            else:
+                return False
         except:
             return False
         
@@ -283,7 +329,6 @@ def lcvis( data, obj_name, period_initial ):
         if show_model == True or show_model == False:
             cwd = os.getcwd()
             os.chdir(cwd)
-            filename = f'{object_name}_lcvisNoModel.pkl'
             ymax, ymin = ax.get_ylim()
             fig2, ax2 = plt.subplots()
             plt.gca().invert_yaxis()
@@ -303,83 +348,152 @@ def lcvis( data, obj_name, period_initial ):
             #p = plt.scatter(x1,y1)
             p = plt.errorbar(x1,y1,yerr = yerror,fmt="o",elinewidth=1)
             
+            #name file
             if show_model == True:
-                filename = f'{object_name}_lcvis.pkl'
-                x_sin_scatter = x1
-                y_sin_scatter2 = list()
-                y_sin_datashift = 0.5 * (max(y1)+min(y1))
-                y_sin_shift = modely_manualshift + y_sin_datashift
-                
-                if curve_type == 'sine':
-                    #update sine curve
-        
-                    y_sin_curve2 = np.sin((sin_width * (x_sin_curve - modelx_manualshift))) * (amp_data + amp_manual) + y_sin_shift
-                    curve2, = plt.plot(x_sin_curve,y_sin_curve2,'g-')
-        
-                    #update sine scatter
-                    for x_val in x_sin_scatter:
-                        y_val = np.sin((sin_width * (x_val - modelx_manualshift))) * (amp_data + amp_manual) + y_sin_shift
-                        y_sin_scatter2.append(y_val)
-                    data_expected2 = plt.scatter(x_sin_scatter,y_sin_scatter2,c='tab:orange')
-                    
-                    x2_calculated = find_X2(x_sin_scatter, y1, y_sin_scatter2, save)
-                    
-                    fig2.text(0.1,0.27,'Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * sin[' + str( round(sin_width,6) )
-                                        + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_sin_shift,6)) + '\n' 
-                                        + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
-                                        + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
-                                        + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
-                    fig2.text(0.65,0.27, 'X2: ' + str( round(x2_calculated,6) ))
-                    
-        
-                if curve_type == 'abs sine':
-                    #update absolute sine curve
-                    
-                    y_sin_curve2 = -abs(np.sin((sin_width * (x_sin_curve - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
-                    curve2, = plt.plot(x_sin_curve,y_sin_curve2,'g-')
-        
-                    #update sine scatter
-                    for x_val in x_sin_scatter:
-                        y_val = -abs(np.sin((sin_width * (x_val - modelx_manualshift))) * (amp_data + amp_manual)) + y_sin_shift
-                        y_sin_scatter2.append(y_val)
-                    data_expected2 = plt.scatter(x_sin_scatter,y_sin_scatter2,c='tab:orange')
-                    
-                    x2_calculated = find_X2(x_sin_scatter, y1, y_sin_scatter2, save)
-                    
-                    fig2.text(0.1,0.27,'Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * |sin[' + str( round(sin_width,6) )
-                                        + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')]| + ' + str( round(y_sin_shift,6)) + '\n' 
-                                        + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
-                                        + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
-                                        + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
-                    fig2.text(0.65,0.27, 'First Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
-                                        + 'Second Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
-                                        + 'Maxima X2: ' + str( round(x2_calculated[2],6) ))
-                
-                plt.legend([p, data_expected2, curve2], ['Observed Data with Error', 'Expected Data on Model', 'Curve Model'],
-                           loc = 'lower right')
-                
+                file_input = tkinter.simpledialog.askstring('File Name', 'File Name (will be given _lcvis.pkl extension): ')
+                extension = '_lcvis.pkl'
             elif show_model == False:
-                plt.legend([p], ['Observed Data with Error'], loc = 'lower right')
+                file_input = tkinter.simpledialog.askstring('File Name', 'File Name (will be given _lcvisNoModel.pkl extension): ')
+                extension = '_lcvisNoModel.pkl'
+            file_path = './' + f'{file_input}' + f'{extension}'
             
-            fig2.text(0.53,0.27, 'Guess Period: ' + str(period_initial) + '\n' + 'Plot Period: ' + str(round(per,6)))
+            #assign default name to filename
+            if file_input == None or file_input == '':
+                index = 0
+                file_input = 'unnamed' + str(index)
+                file_path = './' + f'{file_input}' + f'{extension}'
+                while os.path.isfile(file_path):
+                    index += 1
+                    file_input = 'unnamed' + str(index)
+                    file_path = './' + f'{file_input}' + f'{extension}'
             
-            fig2.suptitle('Lcvis Plot for ' + obj_name)
+            filename = f'{file_input}' + f'{extension}'
             
-            ax2.set_ylim(top = ymin, bottom = ymax)
-
-            fig2.text(0.4,0.27, 'Magnitude Min: ' + str(round(ymin,6)) + '\n'
-                                + 'Magnitude Max: ' + str(round(ymax,6)) + '\n'
-                                + 'Magnitude Range: ' + str(round(ymax - ymin,6)))
+            #check to see if file exists in current directory
+            if os.path.isfile(file_path):
+                overwrite = tkinter.messagebox.askyesno(title='Overwrite?', message="Overwrite " + f"{filename}" + '?')
+            else:
+                overwrite = True
             
-            pickle.dump(fig2, open(f'{filename}', 'wb'))
-            preview_plot = tkinter.messagebox.askyesno(title='Show plot?', message="Would you like to view the saved plot?")
-            if preview_plot:
-                fig2.show()
+            #write file if filename does not exist, or if overwrite is true
+            if overwrite:
+                if show_model == True:
+                    x_scatter = x1
+                    y_scatter2 = list()
+                    y_datashift = 0.5 * (max(y1)+min(y1))
+                    y_shift = modely_manualshift + y_datashift
+                    
+                    if curve_type == 'sine':
+                        #update sine curve
+            
+                        y_sin_curve2 = np.sin((sin_width * (x_curve - modelx_manualshift - 0.25))) * (amp_data + amp_manual) + y_shift
+                        curve2, = plt.plot(x_curve,y_sin_curve2,'g-')
+            
+                        #update sine scatter
+                        for x_val in x_scatter:
+                            y_val = np.sin((sin_width * (x_val - modelx_manualshift - 0.25))) * (amp_data + amp_manual) + y_shift
+                            y_scatter2.append(y_val)
+                        data_expected2 = plt.scatter(x_scatter,y_scatter2,c='tab:orange')
+                        
+                        x2_calculated = find_X2(x_scatter, y1, y_scatter2, save)
+                        
+                        fig2.text(0.1,0.27,'Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * sin[' + str( round(sin_width,6) )
+                                            + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_shift,6)) + '\n' 
+                                            + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
+                                            + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
+                                            + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
+                        fig2.text(0.65,0.27, 'X2: ' + str( round(x2_calculated,6) ))
+                        
+            
+                    elif curve_type == 'sech_sec':
+                        #update secanth-secant curve
+                        curve2, = plt.plot(curve.get_xdata(), curve.get_ydata(), 'k-')
+                        min1_l2, = plt.plot(np.resize(min1_l.get_xdata(), len(min1_l.get_ydata())),
+                                            min1_l.get_ydata(), color = 'crimson', ls = '-', lw = 2)
+                        min1_r2, = plt.plot(np.resize(min1_r.get_xdata(), len(min1_r.get_ydata())),
+                                            min1_r.get_ydata(), color = 'crimson', ls = '-', lw = 2)
+                        min2_l2, = plt.plot(np.resize(min2_l.get_xdata(), len(min2_l.get_ydata())),
+                                            min2_l.get_ydata(), color = 'green', ls = '-', lw = 2)
+                        min2_r2, = plt.plot(np.resize(min2_r.get_xdata(), len(min2_r.get_ydata())),
+                                            min2_r.get_ydata(), color = 'green', ls = '-', lw = 2)
+                        #update sine scatter
+                        for x_val in x_scatter:
+                            y_val = -(amp_data + amp_manual) / ( np.cosh((min_width) / np.cos(2 * np.pi * (x_val - modelx_manualshift))) ) + y_shift
+                            y_scatter2.append(y_val)
+                        data_expected2 = plt.scatter(x_scatter,y_scatter2,c='tab:orange')
+                        
+                        x2_calculated = find_X2(x_scatter, y1, y_scatter2, save)
+                        
+                        fig2.text(0.1,0.27,'Model Equation: -' + str( round(amp_data + amp_manual, 6) ) + ' * sech{' + str( round(min_width,6) ) 
+                                            + ' * sec[2pi * (x - ' + str(round(modelx_manualshift,6)) + ')]} + ' + str(round(y_shift,6)) + '\n' 
+                                            + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
+                                            + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
+                                            + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) + '\n'
+                                            + 'Minimum Extrema Width: ' + str( round( min_width, 6) ) )
+                        fig2.text(0.65,0.27, 'Red Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
+                                            + 'Green Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
+                                            + 'Maxima X2: ' + str( round(x2_calculated[2],6) ) + '\n'
+                                            + 'Minima X2 Width: ' + str( round(chi_width,6) ))
+                        
+                        
+                    elif curve_type == 'abs_sine':
+                        #update absolute sine curve
+                        curve2, = plt.plot(curve.get_xdata(),curve.get_ydata(),'k-')
+                        min1_l2, = plt.plot(np.resize(min1_l.get_xdata(), len(min1_l.get_ydata())),
+                                            min1_l.get_ydata(), color = 'crimson', ls = '-', lw = 2)
+                        min1_r2, = plt.plot(np.resize(min1_r.get_xdata(), len(min1_r.get_ydata())),
+                                            min1_r.get_ydata(), color = 'crimson', ls = '-', lw = 2)
+                        min2_l2, = plt.plot(np.resize(min2_l.get_xdata(), len(min2_l.get_ydata())),
+                                            min2_l.get_ydata(), color = 'green', ls = '-', lw = 2)
+                        min2_r2, = plt.plot(np.resize(min2_r.get_xdata(), len(min2_r.get_ydata())),
+                                            min2_r.get_ydata(), color = 'green', ls = '-', lw = 2)
+            
+                        #update sine scatter
+                        for x_val in x_scatter:
+                            y_val = -abs(np.sin((sin_width * (x_val - modelx_manualshift - 0.25))) * (amp_data + amp_manual)) + y_shift
+                            y_scatter2.append(y_val)
+                        data_expected2 = plt.scatter(x_scatter,y_scatter2,c='tab:orange')
+                        
+                        x2_calculated = find_X2(x_scatter, y1, y_scatter2, save)
+                        
+                        fig2.text(0.1,0.27,'Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * |sin[' + str( round(sin_width,6) )
+                                            + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')]| + ' + str( round(y_shift,6)) + '\n' 
+                                            + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
+                                            + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
+                                            + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
+                        fig2.text(0.65,0.27, 'Red Minima X2: ' + str( round(x2_calculated[0],6) ) + '\n'
+                                            + 'Green Minima X2: ' + str( round(x2_calculated[1],6) ) + '\n'
+                                            + 'Maxima X2: ' + str( round(x2_calculated[2],6) ) + '\n'
+                                            + 'Minima X2 Width: ' + str( round(chi_width,6) ))
+                    
+                    plt.legend([p, data_expected2, curve2], ['Observed Data with Error', 'Expected Data on Model', 'Curve Model'],
+                               loc = 'lower right')
+                    
+                elif show_model == False:
+                    plt.legend([p], ['Observed Data with Error'], loc = 'lower right')
                 
-            tkinter.messagebox.showinfo(title='Figure Saved', message=f"A pickle plot of the light curve named {filename}"
-                                        + f" has been saved in {cwd}"
-                                        + "\n\n" + "Plot cannot be changed when opening with unpickle.py")
-            plt.figure(fig.number)
+                fig2.text(0.53,0.27, 'Guess Period: ' + str(period_initial) + '\n' + 'Plot Period: ' + str(round(per,6)))
+                
+                fig2.suptitle('Lcvis Plot for ' + filename)
+                
+                ax2.set_ylim(top = ymin, bottom = ymax)
+    
+                fig2.text(0.4,0.27, 'Magnitude Min: ' + str(round(ymin,6)) + '\n'
+                                    + 'Magnitude Max: ' + str(round(ymax,6)) + '\n'
+                                    + 'Magnitude Range: ' + str(round(ymax - ymin,6)))
+                
+                pickle.dump(fig2, open(f'{filename}', 'wb'))
+                preview_plot = tkinter.messagebox.askyesno(title='Show plot?', message="Would you like to view the saved plot?")
+                if preview_plot:
+                    fig2.show()
+                    
+                tkinter.messagebox.showinfo(title='Figure Saved', message=f"A pickle plot of the light curve named {filename}"
+                                            + f" has been saved in {cwd}"
+                                            + "\n\n" + "Plot cannot be changed when opening with unpickle.py")
+                plt.figure(fig.number)
+            #cancel save if overwrite is false
+            else:
+                tkinter.messagebox.showinfo(title='Save Cancelled', message='Cancelled saving plot.')
             
         elif show_model == None:
             tkinter.messagebox.showinfo(title='Save Cancelled', message='Cancelled saving plot.')
@@ -392,16 +506,39 @@ def lcvis( data, obj_name, period_initial ):
         if save_data == True:
             cwd = os.getcwd()
             os.chdir(cwd)
-            phased_init = phaser(data,per,data[0][0])
-            phased = list()
-            for obs in phased_init:
-                if obs[0] < 1:
-                    phased.append(obs)
-            phased.sort()
-            filename = f'{object_name}_lcvis.dat'
-            np.savetxt(filename, phased, fmt = '%.11f')
-            tkinter.messagebox.showinfo(title='Data Saved', message=f"A dat file of the light curve named {filename}"
-                                        + f" has been saved in {cwd}")
+            
+            file_input = tkinter.simpledialog.askstring('File Name', 'Enter file name (will be given _lcvis.dat extension): ')
+            extension = '_lcvis.dat'
+            file_path = './' + f'{file_input}' + f'{extension}'
+            
+            #assign default name to filename
+            if file_input == None or file_input == '':
+                index = 0
+                file_input = 'unnamed' + str(index)
+                file_path = './' + f'{file_input}' + f'{extension}'
+                while os.path.isfile(file_path):
+                    index += 1
+                    file_input = 'unnamed' + str(index)
+                    file_path = './' + f'{file_input}' + f'{extension}'
+            filename = f'{file_input}' + f'{extension}'
+            
+            #check to see if file exists in current directory
+            if os.path.isfile(file_path):
+                overwrite = tkinter.messagebox.askyesno(title='Overwrite?', message="Overwrite " + f"{filename}" + '?')
+            else:
+                overwrite = True
+            
+            #write file if chosen to overwrite current file, or write new file if name doesn't exist in directory
+            if overwrite:
+                phased_init = phaser(data,per,data[0][0])
+                phased = list()
+                for obs in phased_init:
+                    if obs[0] < 1:
+                        phased.append(obs)
+                phased.sort()
+                np.savetxt(filename, phased, fmt = '%.11f')
+                tkinter.messagebox.showinfo(title='Data Saved', message=f"A dat file of the light curve named {filename}"
+                                            + f" has been saved in {cwd}")
                 
         elif save_data == False:
             tkinter.messagebox.showinfo(title='Save Cancelled', message='Cancelled saving data.')
@@ -409,29 +546,47 @@ def lcvis( data, obj_name, period_initial ):
             
 
 
-    #FREQUENCY functions to change the frequency of the displayed sine curve and scatter, or to change to absolute value sine
+    #FREQUENCY functions to change the frequency of the displayed sine curve and scatter, or to change to sech-sec
     def frequency_1x():
         global sin_width
         global curve_type
-        global amp_manual
         curve_type = 'sine'
         sin_width = 2 * np.pi
+        min1_l.set_lw(0)
+        min1_r.set_lw(0)
+        min2_l.set_lw(0)
+        min2_r.set_lw(0)
         redraw_plot()
 
     def frequency_2x():
         global sin_width
         global curve_type
-        global amp_manual
         curve_type = 'sine'
         sin_width = 4 * np.pi
+        min1_l.set_lw(0)
+        min1_r.set_lw(0)
+        min2_l.set_lw(0)
+        min2_r.set_lw(0)
+        redraw_plot()
+        
+    def abssine_curve():
+        global curve_type
+        global sin_width
+        curve_type = 'abs_sine'
+        sin_width = 2 * np.pi
+        min1_l.set_lw(2)
+        min1_r.set_lw(2)
+        min2_l.set_lw(2)
+        min2_r.set_lw(2)
         redraw_plot()
 
-    def abssine_curve():
-        global sin_width
+    def sech_sec_curve():
         global curve_type
-        global amp_manual
-        curve_type = 'abs sine'
-        sin_width = 2 * np.pi
+        curve_type = 'sech_sec'
+        min1_l.set_lw(2)
+        min1_r.set_lw(2)
+        min2_l.set_lw(2)
+        min2_r.set_lw(2)
         redraw_plot()
 
             
@@ -449,6 +604,13 @@ def lcvis( data, obj_name, period_initial ):
             select_modelyshift()
         elif label == 'Model X-Shift':
             select_modelxshift()
+        elif label == 'Min Extrema Width':
+            if curve_type == 'sech_sec':
+                select_minwidth()
+            else:
+                tkinter.messagebox.showerror(title='Error', message='Min Extrema Width can only be adjusted for a '
+                                                                       + 'Hyperbolic-Secant-Secant curve. Setting active argument to Period.')
+                argument_radio.set_active(0)
         setbox.set_val('')
         stepbox.set_val('')
         maxbox.set_val('')
@@ -459,11 +621,19 @@ def lcvis( data, obj_name, period_initial ):
             
     def model_selector(label):
         if label == 'Sine, 1 Cycle per Phase':
+            if curve_type == 'sech_sec':
+                argument_radio.set_active(0)
             frequency_1x()
         elif label == 'Sine, 2 Cycles per Phase':
+            if curve_type == 'sech_sec':
+                argument_radio.set_active(0)
             frequency_2x()
-        elif label == 'Absolute Value Sine':
+        elif label == 'Absolute Sine':
+            if curve_type == 'sech_sec':
+                argument_radio.set_active(0)
             abssine_curve()
+        elif label == 'Hyperbolic-Secant-Secant':
+            sech_sec_curve()
         setbox.set_val('')
         stepbox.set_val('')
         maxbox.set_val('')
@@ -471,10 +641,9 @@ def lcvis( data, obj_name, period_initial ):
         magmax_box.set_val('')
         magmin_box.set_val('')
         magrange_box.set_val('')
-            
-            
-            
-            
+    
+    
+    
     #MAG_RANGER function allows adjustment of the magnitude axis
     def mag_ranger(text):
         if evaluator(text):
@@ -489,11 +658,14 @@ def lcvis( data, obj_name, period_initial ):
             else:
                 ymax, ymin = ax.get_ylim()
                 old = str(round(ymax-ymin,6))
-                tkinter.messagebox.showwarning(title='Error', message='Magnitude range cannot be less than or equal to 0'
+                tkinter.messagebox.showerror(title='Error', message='Magnitude range cannot be less than or equal to 0'
                                                + f' (entered {mag_range}). Old value of {old} preserved.')
                 magrange_box.set_val('')
                 return
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            magrange_box.set_val('')
 
 
 
@@ -523,6 +695,11 @@ def lcvis( data, obj_name, period_initial ):
             global stepsize_modelyshift
             modely_manualshift = modely_manualshift + stepsize_modelyshift
             slider.set_val(modely_manualshift)
+        elif arg_selected == 'Min Extrema Width':
+            global min_width
+            global stepsize_minwidth
+            min_width = min_width + stepsize_minwidth
+            slider.set_val(min_width)
         redraw_plot()
     
 
@@ -553,6 +730,11 @@ def lcvis( data, obj_name, period_initial ):
             global stepsize_modelyshift
             modely_manualshift = modely_manualshift - stepsize_modelyshift
             slider.set_val(modely_manualshift)
+        elif arg_selected == 'Min Extrema Width':
+            global min_width
+            global stepsize_minwidth
+            min_width = min_width - stepsize_minwidth
+            slider.set_val(min_width)
         redraw_plot()
 
 
@@ -562,23 +744,45 @@ def lcvis( data, obj_name, period_initial ):
     def stepper(text):
         global arg_selected
         if evaluator(text):
-            if arg_selected == 'Period':
-                global stepsize_per
-                stepsize_per = eval(text)
-                slider.valstep = stepsize_per
-            elif arg_selected == 'Amplitude':
-                global stepsize_amp
-                stepsize_amp = eval(text)
-                slider.valstep = stepsize_amp
-            elif arg_selected == 'Model X-Shift':
-                global stepsize_modelxshift
-                stepsize_modelxshift = eval(text)
-                slider.valstep = stepsize_modelxshift
-            elif arg_selected == 'Model Y-Shift':
-                global stepsize_modelyshift
-                stepsize_modelyshift = eval(text)
-                slider.valstep = stepsize_modelyshift
-            redraw_plot()
+            if eval(text) > 0:
+                if arg_selected == 'Period':
+                    global stepsize_per
+                    stepsize_per = eval(text)
+                    slider.valstep = stepsize_per
+                elif arg_selected == 'Amplitude':
+                    global stepsize_amp
+                    stepsize_amp = eval(text)
+                    slider.valstep = stepsize_amp
+                elif arg_selected == 'Model X-Shift':
+                    global stepsize_modelxshift
+                    stepsize_modelxshift = eval(text)
+                    slider.valstep = stepsize_modelxshift
+                elif arg_selected == 'Model Y-Shift':
+                    global stepsize_modelyshift
+                    stepsize_modelyshift = eval(text)
+                    slider.valstep = stepsize_modelyshift
+                elif arg_selected == 'Min Extrema Width':
+                    global stepsize_minwidth
+                    stepsize_minwidth = eval(text)
+                    slider.valstep(min_width)
+                redraw_plot()
+            else:
+                if arg_selected == 'Period':
+                    old = stepsize_per
+                elif arg_selected == 'Amplitude':
+                    old = stepsize_amp
+                elif arg_selected == 'Model X-Shift':
+                    old = stepsize_modelxshift
+                elif arg_selected == 'Model Y-Shift':
+                    old = stepsize_modelyshift
+                elif arg_selected == 'Min Extrema Width':
+                    old = stepsize_minwidth
+                tkinter.messagebox.showerror(title='Error', message='Stepsize cannot be less than or equal to 0'
+                                               + f' (entered {text}). Old value of {old} preserved.')
+                stepbox.set_val('')
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            stepbox.set_val('')
 
 
 
@@ -595,7 +799,7 @@ def lcvis( data, obj_name, period_initial ):
                     per = eval(text)
                     slider.set_val(per)
                 else:
-                    tkinter.messagebox.showwarning(title='Error', message='Period cannot be less than or equal to 0'
+                    tkinter.messagebox.showerror(title='Error', message='Period cannot be less than or equal to 0'
                                                    + f' (entered {set_num}). Old value of {per} days preserved.')
                     setbox.set_val('')
             elif arg_selected == 'Amplitude':
@@ -612,7 +816,19 @@ def lcvis( data, obj_name, period_initial ):
                 global modely_manualshift
                 modely_manualshift = eval(text)
                 slider.set_val(modely_manualshift)
+            elif arg_selected == 'Min Extrema Width':
+                global min_width
+                if set_num > 0:
+                    min_width = eval(text)
+                    slider.set_val(min_width)
+                else:
+                    tkinter.messagebox.showerror(title='Error', message='Min Extrema Width cannot be less than or equal to 0'
+                                                   + f' (entered {set_num}). Old value of {per} preserved.')
+                    setbox.set_val('')
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            setbox.set_val('')
 
 
 
@@ -630,7 +846,7 @@ def lcvis( data, obj_name, period_initial ):
                         slider.valmax = per_max
                         slider.ax.set_xlim(slider.valmin,per_max)
                     else:
-                        tkinter.messagebox.showwarning(title='Error', message='Period cannot be less than or equal to 0'
+                        tkinter.messagebox.showerror(title='Error', message='Period cannot be less than or equal to 0'
                                                        + f' (entered {per_max}). Old value of {slider.valmax} days preserved.')
                         maxbox.set_val('')
                         return
@@ -649,25 +865,40 @@ def lcvis( data, obj_name, period_initial ):
                     modely_max = eval(text)
                     slider.valmax = modely_max
                     slider.ax.set_xlim(slider.valmin,modely_max)
+                elif arg_selected == 'Min Extrema Width':
+                    global minwidth_max
+                    if slider_max > 0:
+                        slider.valmax = minwidth_max
+                        slider.ax.set_xlim(slider.valmin,minwidth_max)
+                    else:
+                        tkinter.messagebox.showerror(title='Error', message='Min Extrema Width cannot be less than or equal to 0'
+                                                       + f' (entered {slider_max}). Old value of {slider.valmax} preserved.')
+                        maxbox.set_val('')
             else:
-                tkinter.messagebox.showwarning(title='Error', message='Maximum slider value is less than or equal to minimum slider value'
+                tkinter.messagebox.showerror(title='Error', message='Maximum slider value is less than or equal to minimum slider value'
                                                + f' (entered {slider_max}, min = {slider.valmin}). Old value of {slider.valmax} preserved.')
                 maxbox.set_val('')
                 return
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            maxbox.set_val('')
         
     def mag_maxxer(text):
         if evaluator(text):
             ymax, ymin = ax.get_ylim()
             new_ymax = eval(text)
             if new_ymax <= ymin:
-                tkinter.messagebox.showwarning(title='Error', message='Maximum magnitude is less than or equal to minimum magnitude'
+                tkinter.messagebox.showerror(title='Error', message='Maximum magnitude is less than or equal to minimum magnitude'
                                                + f' (entered {new_ymax}, min = {ymin}). Old value of {ymax} preserved.')
                 magmax_box.set_val('')
                 return
             else:
                 ax.set_ylim(bottom = new_ymax)
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            magmax_box.set_val('')
 
 
 
@@ -685,7 +916,7 @@ def lcvis( data, obj_name, period_initial ):
                         slider.valmin = per_min
                         slider.ax.set_xlim(per_min,slider.valmax)
                     else:
-                        tkinter.messagebox.showwarning(title='Error', message='Period cannot be less than or equal to 0'
+                        tkinter.messagebox.showerror(title='Error', message='Period cannot be less than or equal to 0'
                                                        + f' (entered {per_min}). Old value of {slider.valmin} days preserved.')
                         minbox.set_val('')
                         return
@@ -704,24 +935,40 @@ def lcvis( data, obj_name, period_initial ):
                     modely_min = eval(text)
                     slider.valmin = modely_min
                     slider.ax.set_xlim(modely_min,slider.valmax)
+                elif arg_selected == 'Min Extrema Width':
+                    global minwidth_min
+                    slider_min = eval(text)
+                    if slider_min > 0:
+                        slider.valmin = minwidth_min
+                        slider.ax.set_xlim(minwidth_min,slider.valmax)
+                    else:
+                        tkinter.messagebox.showerror(title='Error', message='Min Extrema Width cannot be less than or equal to 0'
+                                                       + f' (entered {slider_min}). Old value of {slider.valmin} preserved.')
+                        maxbox.set_val('')
             else:
-                tkinter.messagebox.showwarning(title='Error', message='Minimum slider value is greater than or equal to maximum slider value'
+                tkinter.messagebox.showerror(title='Error', message='Minimum slider value is greater than or equal to maximum slider value'
                                                + f' (entered {slider_min}, max = {slider.valmax}). Old value of {slider.valmin} preserved.')
                 minbox.set_val('')
                 return
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            minbox.set_val('')
         
     def mag_minner(text):
         if evaluator(text):
             ymax, ymin = ax.get_ylim()
             new_ymin = eval(text)
             if new_ymin >= ymax:
-                tkinter.messagebox.showwarning(title='Error', message='Minimum magnitude is greater than or equal to maximum magnitude'
+                tkinter.messagebox.showerror(title='Error', message='Minimum magnitude is greater than or equal to maximum magnitude'
                                                + f' (entered {new_ymin}, max = {ymax}). Old value of {ymin} preserved.')
                 magmin_box.set_val('')
             else:
                 ax.set_ylim(top = new_ymin)
             redraw_plot()
+        elif text != '':
+            tkinter.messagebox.showerror(title='Error', message='Only integers and numbers can be entered.')
+            magmin_box.set_val('')
         
         
         
@@ -741,6 +988,16 @@ def lcvis( data, obj_name, period_initial ):
         elif arg_selected == 'Model Y-Shift':
             global modely_manualshift
             modely_manualshift = slider.val
+        elif arg_selected == 'Min Extrema Width':
+            global min_width
+            min_width = slider.val
+        redraw_plot()
+    
+    
+    #CHI_UPDATER function to adjust the width of the chi-range
+    def chi_updater(val):
+        global chi_width
+        chi_width = chislider.val
         redraw_plot()
 
 
@@ -806,16 +1063,47 @@ def lcvis( data, obj_name, period_initial ):
         slider.valstep = stepsize_modelxshift
         slider.set_val(modelx_manualshift)
         redraw_plot()
+        
+    def select_minwidth():
+        Badd.label.set_text('+Min Extrema Width')
+        Bsub.label.set_text('-Min Extrema Width')
+        stepbox.label.set_text('Min Extrema Width Stepsize ')
+        setbox.label.set_text('Adjust Min Extrema Width ')
+        maxbox.label.set_text('Min Extrema Width Max ')
+        minbox.label.set_text('Min Extrema Width Min ')
+        slider.label.set_text('Min Extrema Width')
+        slider.valmax = minwidth_max
+        slider.valmin = minwidth_min
+        slider.ax.set_xlim(minwidth_min,minwidth_max)
+        slider.valstep = stepsize_minwidth
+        slider.set_val(min_width)
+        redraw_plot()
 
 
 
 
     #create plots
     fig, ax = plt.subplots()
-    plt.gca().invert_yaxis()
+    #plt.gca().invert_yaxis()
     plt.xlabel('Phase')
     plt.ylabel('Magnitude')
     plt.subplots_adjust(left=0.1,bottom=0.4,top=0.95)
+    magmin = data[0][1]
+    magmin_error = data[0][2]
+    magmin_lim = magmin - magmin_error - 0.05
+    magmax = data[0][1]
+    magmax_error = data[0][2]
+    magmax_lim = magmax + magmax_error + 0.05
+    for obs in data:
+        if obs[1] < magmin:
+            magmin = obs[1]
+            magmin_error = obs[2]
+            magmin_lim = magmin - magmin_error - 0.05
+        if obs[1] > magmax:
+            magmax = obs[1]
+            magmax_error = obs[2]
+            magmax_lim = magmax + magmax_error + 0.05
+    ax.set_ylim(magmax_lim, magmin_lim)
 
     #gather initial data
     initial = phaser(data,per_initial,data[0][0])
@@ -840,12 +1128,12 @@ def lcvis( data, obj_name, period_initial ):
     q = plt.errorbar(x1,y1,yerr = yerror,fmt="o",elinewidth=1)
 
     #plot initial sin curve, adjusted to data
-    x_sin_curve = np.arange(0,2,0.001)
+    x_curve = np.arange(0,2,0.0001)
     modelx_manualshift = 0
 
-    y_sin_datashift = 0.5 * (max(y1)+min(y1))
+    y_datashift = 0.5 * (max(y1)+min(y1))
     modely_manualshift = 0
-    y_sin_shift = y_sin_datashift
+    y_shift = y_datashift
 
     y1_avg = sum(y1) / len(y1)
     y1_sorted = y1.copy()
@@ -859,43 +1147,61 @@ def lcvis( data, obj_name, period_initial ):
     amp_data = round(((y1_avg - y1_minavg) + (y1_maxavg - y1_avg)) / 2,6)
     sin_width = 2 * np.pi
 
-    y_sin_curve = np.sin(sin_width * x_sin_curve) * amp_data + y_sin_shift
-    curve, = plt.plot(x_sin_curve,y_sin_curve,'g-')
+    y_sin_curve = np.sin(sin_width * x_curve) * amp_data + y_shift
+    curve, = plt.plot(x_curve,y_sin_curve,'k-')  
+    
+    
+    #creating minima bound lines for binary minima chi-square analysis
+    minima_bounds = np.arange(magmin_lim - 0.5,magmax_lim + 0.5,0.5)
+    min1_l_curve = []
+    min1_r_curve = []
+    min2_l_curve = []
+    min2_r_curve = []
+    for i in range(len(minima_bounds)):
+        min1_l_curve.append(0)
+        min1_r_curve.append(0.1)
+        min2_l_curve.append(0.5)
+        min2_r_curve.append(0.6)
+    min1_l, = plt.plot(min1_l_curve, minima_bounds, color = 'crimson', ls = '-', lw = 0)
+    min1_r, = plt.plot(min1_r_curve, minima_bounds, color = 'crimson', ls = '-', lw = 0)
+    min2_l, = plt.plot(min2_l_curve, minima_bounds, color = 'green', ls = '-', lw = 0)
+    min2_r, = plt.plot(min2_r_curve, minima_bounds, color = 'green', ls = '-', lw = 0)
 
     #plot initial sine scatter, adjusted to data. used for x2 calculation
-    x_sin_scatter = x1
-    y_sin_scatter = list()
-    for x_val in x_sin_scatter:
-        y_val = np.sin(sin_width * x_val) * (amp_data) + y_sin_shift
-        y_sin_scatter.append(y_val)
-    data_expected = plt.scatter(x_sin_scatter,y_sin_scatter,c='tab:orange')
+    x_scatter = x1
+    y_scatter = list()
+    for x_val in x_scatter:
+        y_val = np.sin(sin_width * x_val) * (amp_data) + y_shift
+        y_scatter.append(y_val)
+    data_expected = plt.scatter(x_scatter,y_scatter,c='tab:orange')
     
     plt.legend([q, data_expected, curve], ['Observed Data with Error', 'Expected Data on Model', 'Curve Model'], loc = 'lower right')
 
     #calculate initial x2
-    x2_calculated = find_X2(x_sin_scatter, y1, y_sin_scatter, initial)
+    x2_calculated = find_X2(x_scatter, y1, y_scatter, initial)
 
     #create gui for textboxes, buttons, sliders
-    argument_ax = plt.axes([0.06,0.05,0.08,0.12])
-    model_ax = plt.axes([0.17,0.05,0.13,0.12])
+    argument_ax = plt.axes([0.06,0.05,0.10,0.12])
+    model_ax = plt.axes([0.17,0.05,0.14,0.12])
     
-    add = plt.axes([0.34,0.12,0.08,0.03])
-    sub = plt.axes([0.34,0.07,0.08,0.03])
-    steptext = plt.axes([0.66,0.12,0.05,0.03])
-    settext = plt.axes([0.66,0.07,0.05,0.03])
+    add = plt.axes([0.32,0.12,0.08,0.03])
+    sub = plt.axes([0.32,0.07,0.08,0.03])
+    steptext = plt.axes([0.68,0.12,0.05,0.03])
+    settext = plt.axes([0.68,0.07,0.05,0.03])
     maxtext = plt.axes([0.51,0.12,0.05,0.03])
     mintext = plt.axes([0.51,0.07,0.05,0.03])
-    magrange_ax = plt.axes([0.81,0.04,0.05,0.03])
-    magmax_ax = plt.axes([0.81,0.14,0.05,0.03])
-    magmin_ax = plt.axes([0.81,0.09,0.05,0.03])
+    magrange_ax = plt.axes([0.81,0.025,0.05,0.03])
+    magmax_ax = plt.axes([0.81,0.125,0.05,0.03])
+    magmin_ax = plt.axes([0.81,0.075,0.05,0.03])
+    chiwidth_ax = plt.axes([0.61,0.175,0.25,0.03])
     slider_ax = plt.axes([0.1,0.215,0.80,0.03])
     savepkl_ax = plt.axes([0.9,0.12,0.055,0.03])
     savedat_ax = plt.axes([0.9,0.07,0.055,0.03])
 
     #make textboxes, buttons, sliders    
-    argument_radio = RadioButtons(ax=argument_ax, labels=('Period', 'Amplitude', 'Model X-Shift', 'Model Y-Shift'), active=0)
+    argument_radio = RadioButtons(ax=argument_ax, labels=('Period', 'Amplitude', 'Model X-Shift', 'Model Y-Shift', 'Min Extrema Width'), active=0)
     arg_selected = 'Period'
-    model_radio = RadioButtons(ax=model_ax, labels=('Sine, 1 Cycle per Phase', 'Sine, 2 Cycles per Phase', 'Absolute Value Sine'), active=0)
+    model_radio = RadioButtons(ax=model_ax, labels=('Sine, 1 Cycle per Phase', 'Sine, 2 Cycles per Phase', 'Absolute Sine', 'Hyperbolic-Secant-Secant'), active=0)
     
     Badd = Button(ax=add,label='+Period')
     Bsub = Button(ax=sub,label='-Period')
@@ -906,6 +1212,7 @@ def lcvis( data, obj_name, period_initial ):
     magrange_box = TextBox(magrange_ax, 'Magnitude Range ')
     magmax_box = TextBox(magmax_ax, 'Magnitude Max ')
     magmin_box = TextBox(magmin_ax, 'Magnitude Min ')
+    chislider = Slider(chiwidth_ax, 'Absolute Sine and Hyperbolic-Secant-Secant Only: Minima X2 Width', 0.05, 0.3, valinit = 0.1, valstep = 0.01)
     slider = Slider(slider_ax, 'Period', 0.000001, 10, valinit = 0,valstep = stepsize_per)
     slider.set_val(per)
     Bsavepkl = Button(ax=savepkl_ax,label='Save as .pkl')
@@ -924,6 +1231,7 @@ def lcvis( data, obj_name, period_initial ):
     magrange_box.on_submit(mag_ranger)
     magmax_box.on_submit(mag_maxxer)
     magmin_box.on_submit(mag_minner)
+    chislider.on_changed(chi_updater)
     slider_id = slider.on_changed(updater)
     Bsavepkl.on_clicked(save_pkl)
     Bsavedat.on_clicked(save_dat)
@@ -939,7 +1247,7 @@ def lcvis( data, obj_name, period_initial ):
                     + "Data centered at magnitude " + str(round(centered,6)))
     
     eq_info = fig.text(0.1,0.27, 'Model Equation: ' + str( round(amp_data + amp_manual,6) ) + ' * sin[' + str( round(sin_width,6) )
-                        + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_sin_shift,6)) + '\n' 
+                        + ' * (x - ' + str( round(modelx_manualshift,6) ) + ')] + ' + str( round(y_shift,6)) + '\n' 
                         + 'Model Amplitude: ' + str( round(amp_data + amp_manual,6) ) + '\n'
                         + 'Manually Adjusted Model X-Shift: ' + str( round(modelx_manualshift,6) ) + '\n'
                         + 'Manually Adjusted Model Y-Shift: ' + str( round(modely_manualshift,6) ) )
@@ -958,12 +1266,14 @@ def lcvis( data, obj_name, period_initial ):
 
     per_max = 10
     per_min = 0.000001
-    amp_max = round(0.5 * (max(y1)-min(y1)) + 0.1,6)
+    amp_max = round(0.5 * (max(y1)-min(y1)) + 0.5,6)
     amp_min = 0
     modelx_max = 1
     modelx_min = -1
     modely_max = max(y1)-min(y1)
     modely_min = min(y1)-max(y1)
+    minwidth_min = 0.000001
+    minwidth_max = 5
     
     #show plot
     plt.show()
@@ -972,15 +1282,16 @@ def lcvis( data, obj_name, period_initial ):
 
 import numpy as np
 import argparse
+import os
 
 #create arguments
 parser = argparse.ArgumentParser()
 parser.add_argument("indata", help = "Object's unconex data file")
-parser.add_argument("object_name", help = "Object's name to use for saving purposes and plot title")
-parser.add_argument("--initial_period", "-p", default = 1, help = "Initial period for plot; use single_phase period on unconex data")
+#parser.add_argument("object_name", help = "Object's name to use for saving purposes and plot title")
+parser.add_argument("--initial_period", "-p0", default = 1, help = "Initial period for plot; use single_phase period on unconex data")
 args = parser.parse_args()
 indata = args.indata
-object_name = args.object_name
+object_name = os.path.basename(indata)
 
 #set initial period to 1, step size to 0.000001, initial model to sine
 per = float(args.initial_period)
@@ -990,7 +1301,10 @@ stepsize_phase = 0.000001
 stepsize_amp = 0.000001
 stepsize_modelxshift = 0.000001
 stepsize_modelyshift = 0.000001
+stepsize_minwidth = 0.000001
 curve_type = 'sine'
+min_width = 0.1
+chi_width = 0.1
 
 #use lcvis function
 use = (np.loadtxt(indata)).tolist()


### PR DESCRIPTION
# LCvis Update
This pull request outlines the various additions and changes made to lcvis.py. A new fitting function has been introduced and quality of life changes have been made.



## Summary
### Command Line Changes
- New way to run the program (see Section 1)
### Major Additions and Changes
- Added a Hyperbolic-Secant-Secant (SechSec) function
  - Takes the form sech(sec(x))
  - Allows for better fits on certain systems such as contact binaries, systems with flat minima, and some algols
  - Introduces new adjustment: Min Extrema Width
- Added chi-square boundary slider
  - Allows for custom selection of minima points on Absolute-Sine (AbsSine) and SechSec models
  - Adds vertical lines (red for one minima, green for the other) to show the observations point being taking into account for chi-square calculation
  - Slider has a range of 0.05 to 0.3, with a stepsize of 0.01
### Additional Changes
- Save .pkl and save .dat files have been completely overhauled (see Section 3)
### Error Prevention
- Additional measures to prevent invalid inputs into textboxes (see Section 4)
### Miscellaneous
- Critical fix made in chi-square calculation (see Section 5)
- Known error in the new model (see Section 6)
  - Does not affect program running or calculations



## Section 1: Command Line Changes
Due to the various changes of the program, the prompt to run lcvis has changed slightly. To now use lcvis, type `python3 lcvis.py (dat file) [-p0] [initial period]`. The initial period argument has been changed from `-p` to `-p0` for better identification. Various examples are below:
- `python3 lcvis.py J1125+4234_unconex.dat` Both lcvis and the .dat file are in the same directory; no initial period given (defaults to 1)
- `python3 lcvis.py J1125+4234_unconex.dat -p0 0.5` Both lcvis and the .dat file are in the same directory; initial period of 0.5 days
- `python3 ~/vsp/ceph_tools/lcvis.py ~/vsp/xtetrans_b/J1125+4234/J1125+4234_unconex.dat -p0 0.349768` The lcvis file is located in the ~/vsp/ceph_tools directory. The .dat file is located in the ~/vsp/xtetrans_b/J1125+4234 directory. Initial period of 0.349768 days
You can use `python3 lcvis.py -h` for info on how to use the program.
![image](https://github.com/rotsehub/rotseana/assets/130495218/f3e15541-5e90-4df6-a7e2-de21fb6f5e49)



## Section 2: Major Additions
### Hyperbolic-Secant-Secant (SechSec) Model
A brand new model has been introduced into the lcvis program. Called Hyperbolic-Secant-Secant (SechSec), the model allows for a better fit for eclipsing systems. The AbsSine function remains within the program, however SechSec features a shape that better represents elongated contact stars and contact systems with different sized stars (flat minima). Below are a few examples of the new model fit to various binary systems, along with their fits against the AbsSine model.

![image](https://github.com/rotsehub/rotseana/assets/130495218/559a73c2-79b0-4995-b52f-808b65f0947f)
![image](https://github.com/rotsehub/rotseana/assets/130495218/d19415ad-239d-49f5-88d0-3738830d790a)
A contact system with drastically different minima. (AbsSine top; SechSec bottom)

![image](https://github.com/rotsehub/rotseana/assets/130495218/bb9721fd-eab9-43ce-b27c-717f7e770443)
![image](https://github.com/rotsehub/rotseana/assets/130495218/fb1db47b-e24f-4bec-9d03-f6003f6c966e)
A contact system with fairly similar, flat minima. (AbsSine top; SechSec bottom)

![image](https://github.com/rotsehub/rotseana/assets/130495218/231709fa-499d-4c3c-80ea-901317617a83)
![image](https://github.com/rotsehub/rotseana/assets/130495218/21349cf5-69a5-4a43-a9a3-900356d647d2)
An algol. (AbsSine top; SechSec bottom)


#### Using the new model
In order to use the new model, select "Hyperbolic-Secant-Secant" from the Models box (circled in red below).
![image](https://github.com/rotsehub/rotseana/assets/130495218/d8851803-17a2-43a0-97ab-e87967c13530)

Once selected, a model like the one below should appear. Note the equation next to the red arrow.
![image](https://github.com/rotsehub/rotseana/assets/130495218/3289476d-8396-4217-b57a-62214377e018)


#### Arguments
Like the Sine models and the AbsSine model, the SechSec model can be adjusted in amplitude, horizontal shift, and vertical shift. Unlike the other three models, the SechSec model has an additional adjustment: **Min Extrema Width**. This argument allows you to adjust the width of the minima in the function, and triples as a slight amplitude adjustment and overall curve smoother.

Below are three plots of the same object with the same amplitude, horizontal shift, and vertical shift in the model. The top plot has a min extrema width value of 0.1, the middle 0.7, and the bottom 1.8.
![image](https://github.com/rotsehub/rotseana/assets/130495218/795f765c-1bbb-4c9d-ba8a-16374a95be62)
![image](https://github.com/rotsehub/rotseana/assets/130495218/a25112e9-7688-4efb-99bf-8d6889f4b353)
![image](https://github.com/rotsehub/rotseana/assets/130495218/57584878-bdfa-45c2-87f5-d66b596aec7a)
Note that the argument **can only be applied to the SechSec model**. If the argument is selected for any other model, an error is thrown and the argument selector defaults back to Period.


### Chi-Square Bounds
Two new pairs of vertical lines have been added to the plot to identify the points which are taken for chi-square analysis. These red and green lines highlight the respective minima of the model and are vital in identifying the observed minima of objects. In addition, a chi-slider (red arrows) has been added beneath the main slider to adjust the bounds of the points to be taken for chi-square analysis. The slider has a minimum width pf 0.05 and a maximum of 0.30, with a stepsize of 0.01.
![image](https://github.com/rotsehub/rotseana/assets/130495218/5a658b88-ccb0-4f2a-b2bb-0397e32bcccd)

See below how the chi-square values change when the boundaries are increased or decreased. The first plot has a chi-square width of 0.05, the second a width of 0.15, and the third a width of 0.30.
![image](https://github.com/rotsehub/rotseana/assets/130495218/99b24381-ff51-4a6a-abb5-7aecf4e0f647)
![image](https://github.com/rotsehub/rotseana/assets/130495218/778005ad-0f28-41da-bdfd-a36b49b4f26d)
![image](https://github.com/rotsehub/rotseana/assets/130495218/21b035f7-4f9b-4033-8b2e-8d984920cbb2)



## Section 3: Saving Files
Saving the plot or the data has received a complete overhaul. You will now need to provide a name for the file before saving it. If no name is given to the file, a default name will be given to the file. If a file name already exists in the current directory, you will be asked if you would like to overwrite the file. When saving a .pkl file, the following prompts are shown:
![image](https://github.com/rotsehub/rotseana/assets/130495218/eb1d0e4a-1f24-44e7-a3ed-f78a674f65c0)
Save plot with model prompt. Selecting "Yes" will save the black model curve and orange expected data on the plot along with the blue observed data. Selecting "No" will only save the blue observed data. Selecting "Cancel" will cancel the save.

![image](https://github.com/rotsehub/rotseana/assets/130495218/49525b45-22b9-4204-b265-a9074b36bef5)
![image](https://github.com/rotsehub/rotseana/assets/130495218/3c3bb790-b1bb-4799-bc82-1b0e8af38deb)
These prompts appear after selecting either "Yes" or "No" on the previous Save Model prompt. The extension "_lcvis.pkl" is given to files that save with the black model and orange observed data, the extension "_lcvisNoModel.pkl" is given to files that save without them. In the event no name is given or "Cancel" is selected, the file will be given a unique default "unnamed" file name (ex, unnamed0_lcvis.pkl).

![image](https://github.com/rotsehub/rotseana/assets/130495218/fa841fc2-4860-45ab-ae89-623ba830b032)
In either case, if a file name input into the prompt already exists in the directory, an overwrite confirmation will be displayed. Selecting "Yes" will overwrite the file. Selecting "No" will cancel the save.

![image](https://github.com/rotsehub/rotseana/assets/130495218/4381c615-a3d3-4d16-ac93-7a45fdf93449)
Once a file name has been given, a show plot prompt will appear. You can either immediately view the saved plot by clicking "Yes" or disregard the message by clicking "No" to not view the saved plot. A saved plot only contains the information above the main slider and none of the plot adjustment buttons or text boxes. A saved plot cannot be modified once saved.

![image](https://github.com/rotsehub/rotseana/assets/130495218/0ef50bcf-99d1-4f51-9b32-9e12d3112625)
![image](https://github.com/rotsehub/rotseana/assets/130495218/f91fb025-629d-49b3-b806-3220f5831db6)
If a name has been given to the file, a prompt similar to the top image will be displayed. If no name was given to the file, a prompt like the one below will be shown. Note that if no name is given to the file, the program defaults the file to "unnamed" with a unique number. Notice in this instance, the file is named "unnamed2_lcvisNoModel.pkl". The program recognizes that "unnamed0" and "unnamed1" are already files existing inside the directory, so it creates a new default unique file name.

The same prompts are shown when saving a .dat file, however the Save Model prompt is now simply a Save Data prompt, and the Show Model prompt is not shown. A "_lcvis.dat" extension is given to all files.


## Section 4: Error Prevention
Additional steps have been taken to ensure that certain user inputs are not taken by the program. The following error messages added are listed below, along with their respective error boxes at the end of the summary.
- Stepsize can no longer be set to a value less than or equal to 0
- Only integer and float inputs are allowed to be entered into text boxes
- Min Extrema Width can only be selected when the Hyperbolic-Secant-Secant model is selected
![image](https://github.com/rotsehub/rotseana/assets/130495218/acf46bf8-e9e8-4d36-8425-31fb15221aa0)
![image](https://github.com/rotsehub/rotseana/assets/130495218/efdb552b-a1e8-4fe7-8657-2d6584eb9d53)
![image](https://github.com/rotsehub/rotseana/assets/130495218/7647b94f-c74f-4e90-8dcb-a0b654bd6350)


## Section 5: Chi-Square Calculation Fix
A critical error was found in the previous version of lcvis when calculating the chi-square value of each minima when the model was set to AbsSine (the SechSec model uses the same calculations). The old program originally highlighted an area of 0.2 around a minima of the model, then found the second minima by expanding the bounds of the first minima. Thus, the first chi-square value reported the fit of the first minima with a width of 0.2, while the second chi-square value reported the fit of the first minima again, but with a width of 0.4. This update has fixed the issue, and now both chi-square values should be reporting the correct value for each set of points in encapsulates.


## Section 6: Known Errors
There is a bug within the new version of lcvis. Since the new model uses a secant function, the program will encounter an overflow error when the value inside the secant function is extremely close to a multiple of one-half-pi. However, since the hyperbolic-secant then evaluates the value of the secant function (which is infinity), the correct number of 0 is displayed. In other words, although `sec(pi/2) = inf` and causes an overflow warning, `sech(sec(pi/2)) = 0` and does not crash the program. Although the overflow error (below) is displayed, a few tests with random data have shown that this does not throw out the point and the value is still taken into account for the chi-square calculation. Thus, this error is not program-breaking, and at the moment is only causing annoyances within the command terminal while not affecting any values (see below for the error).
![image](https://github.com/rotsehub/rotseana/assets/130495218/b85f8901-2c2f-4c1f-8341-0bef2c12cd13)